### PR TITLE
Change deployment availability check

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParsingDefaultMinReadyReplicas(t *testing.T) {
+	configFile := "testdata/service1.yaml"
+	services, err := Parse(configFile)
+
+	if err != nil {
+		t.Errorf("Failed to parse config file: %s", configFile)
+	}
+
+	minReadyReplicas := services[0].MinReadyReplicas
+
+	if minReadyReplicas != 1 {
+		t.Errorf("Expected minReadyReplicas to be %d, but found %d", 1, minReadyReplicas)
+	}
+}

--- a/config/parser.go
+++ b/config/parser.go
@@ -32,6 +32,15 @@ func Parse(configPath string) ([]Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	applyDefaultsTo(&serviceConfigs)
 
 	return serviceConfigs, nil
+}
+
+func applyDefaultsTo(services *[]Service) {
+	for i := range *services {
+		if (*services)[i].MinReadyReplicas < 1 {
+			(*services)[i].MinReadyReplicas = 1
+		}
+	}
 }

--- a/config/service.go
+++ b/config/service.go
@@ -1,8 +1,9 @@
 package config
 
 type Service struct {
-	Name           string `yaml:"name"`
-	DeploymentName string `yaml:"deploymentName"`
-	Namespace      string `yaml:"namespace"`
-	ApiPath        string `yaml:"apiPath"`
+	Name             string `yaml:"name"`
+	DeploymentName   string `yaml:"deploymentName"`
+	Namespace        string `yaml:"namespace"`
+	ApiPath          string `yaml:"apiPath"`
+	MinReadyReplicas int32  `yaml:"minReadyReplicas"`
 }

--- a/config/testdata/service1.yaml
+++ b/config/testdata/service1.yaml
@@ -1,0 +1,4 @@
+- name: "Minio"
+  deploymentName: "minio"
+  namespace: "default"
+  apiPath: "/minio"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/api v0.19.0
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v0.19.0
 )

--- a/internal/kubernetes/statusclient.go
+++ b/internal/kubernetes/statusclient.go
@@ -12,7 +12,7 @@ import (
 
 type StatusClient struct {
 	k8sClient *kubernetes.Clientset
-	logger *zap.SugaredLogger
+	logger    *zap.SugaredLogger
 }
 
 func NewStatusClient(kubeConfigPath string, logger *zap.SugaredLogger) (*StatusClient, error) {
@@ -38,7 +38,7 @@ func NewStatusClient(kubeConfigPath string, logger *zap.SugaredLogger) (*StatusC
 
 	return &StatusClient{
 		k8sClient: k8sClient,
-		logger: logger,
+		logger:    logger,
 	}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -48,7 +48,7 @@ func registerTargets(services []config.Service, statusClient *kubernetes.StatusC
 func registerTarget(service config.Service, statusClient *kubernetes.StatusClient, logger *zap.SugaredLogger) {
 	http.HandleFunc(fmt.Sprintf("%s", service.ApiPath), func(w http.ResponseWriter, r *http.Request) {
 		logger.Debugf("request URL was: %s", r.URL)
-		isReady, err := statusClient.IsDeploymentReady(service.DeploymentName, service.Namespace)
+		isReady, err := statusClient.IsDeploymentReady(service.DeploymentName, service.Namespace, service.MinReadyReplicas)
 		if err != nil {
 			logger.Errorf("error getting service status for service '%s'. err: %s", service.Name, err)
 		}

--- a/services.yaml
+++ b/services.yaml
@@ -2,9 +2,11 @@
 - name: "Minio"
   deploymentName: "minio"
   namespace: "default"
+  minReadyReplicas: 2 # defaults to 1 if omitted
   apiPath: "/minio"
 - name: "nginx"
   deploymentName: "nginx"
   namespace: "default"
+  minReadyReplicas: 3 # defaults to 1 if omitted
   apiPath: "/nginx"
 


### PR DESCRIPTION
Change the test for deployment availability to check for a configurable number of ready replicas, rather than requiring all replicas in a deployment to be ready.

This PR adds a new (optional) field, `minReadyReplicas` to configuration files:

```yaml
- name: "Minio"
  deploymentName: "minio"
  namespace: "default"
  minReadyReplicas: 2 # defaults to 1 if omitted
  apiPath: "/minio"
- name: "nginx"
  deploymentName: "nginx"
  namespace: "default"
  minReadyReplicas: 3 # defaults to 1 if omitted
  apiPath: "/nginx"
```

The deployment check will then test if at least that number of replicas are in a ready state in order to determine deployment availability.

Fixes #1.